### PR TITLE
Use same voice path in Makefile and asl-tts

### DIFF
--- a/bin/asl-tts
+++ b/bin/asl-tts
@@ -6,7 +6,7 @@
 # https://opensource.org/license/mit
 #
 
-ONNX_FILES="/var/lib/piper-tts"
+ONNX_FILES="/usr/lib/piper-tts/voices"
 PIPER="/usr/bin/piper"
 
 if [ ${USER} != "root" ] && [ ${USER} != "asterisk" ]; then


### PR DESCRIPTION
I noticed the voice path from the Makefile is different than the asl-tts script, this PR makes them the same (the Makefile is untouched, the asl-tts script is modified). 