### PR TITLE
Remove voice file after it is played to the node.

### DIFF
--- a/bin/asl-tts
+++ b/bin/asl-tts
@@ -73,9 +73,9 @@ sox -V ${FILE} -r 8000 -c 1 -t ul ${FILE}.ul 2> ${LOGFILE}
 
 if [ ${MODE} == "SPEAK" ]; then
 	asterisk -x "rpt localplay ${NODE} ${FILE}"
+	rm ${FILE}
 fi
 
-rm ${FILE}
 
 if [ "${EXITVAL}" == "1" ]; then
 	cat ${LOGFILE}

--- a/bin/asl-tts
+++ b/bin/asl-tts
@@ -73,7 +73,7 @@ sox -V ${FILE} -r 8000 -c 1 -t ul ${FILE}.ul 2> ${LOGFILE}
 
 if [ ${MODE} == "SPEAK" ]; then
 	asterisk -x "rpt localplay ${NODE} ${FILE}"
-	rm ${FILE}
+	rm ${FILE}.ul
 fi
 
 


### PR DESCRIPTION
This is a simple pull request. It moves the file delete to inside the SPEAK check so that the file is deleted after it is played to the node.  If a filename is given on the command line, it is not deleted.   I also added the .ul extension for the file.

Kirk (VE6KIK)