### PR TITLE
Added cleanup switch to cleanup voice files after paying.

### DIFF
--- a/bin/asl-tts
+++ b/bin/asl-tts
@@ -10,6 +10,8 @@ set -e
 
 ONNX_FILES="/var/lib/piper-tts"
 PIPER="/usr/bin/piper"
+SOXI="/usr/bin/soxi"
+CLEAN="NO"
 
 if [ ${USER} != "root" ] && [ ${USER} != "asterisk" ]; then
 	echo "Script must be run as root or asterisk"
@@ -21,12 +23,13 @@ function usage(){
 	exit 1
 }
 
-while getopts "f:n:t:v:" opt; do
+while getopts "f:n:t:v:c" opt; do
 	case ${opt} in
 		f)  FILE="${OPTARG}" ;;
 		n)	NODE="${OPTARG}" ;;
 		t)	TEXT="${OPTARG}" ;;
 		v)  VOICE="${OPTARG}" ;;
+		c)  CLEAN="YES";;
 		*)	usage ;;
 	esac
 done
@@ -73,9 +76,15 @@ sox -V ${FILE} -r 8000 -c 1 -t ul ${FILE}.ul 2> ${LOGFILE}
 
 if [ ${MODE} == "SPEAK" ]; then
 	asterisk -x "rpt localplay ${NODE} ${FILE}"
-	rm ${FILE}.ul
+
+	if [ ${CLEAN} == "YES" ]; then    	# Delay to allow the sound to be played and then cleanup.
+		RUNTIME=`${SOXI} -D ${FILE}.ul 2>${LOGFILE}`	# Get the length of the sound (in seconds)
+		sleep ${RUNTIME}
+		rm ${FILE}.ul
+	fi
 fi
 
+rm ${FILE}
 
 if [ "${EXITVAL}" == "1" ]; then
 	cat ${LOGFILE}

--- a/bin/asl-tts
+++ b/bin/asl-tts
@@ -73,9 +73,9 @@ sox -V ${FILE} -r 8000 -c 1 -t ul ${FILE}.ul 2> ${LOGFILE}
 
 if [ ${MODE} == "SPEAK" ]; then
 	asterisk -x "rpt localplay ${NODE} ${FILE}"
+	rm ${FILE}
 fi
 
-rm ${FILE}
 
 if [ "${EXITVAL}" == "1" ]; then
 	cat ${LOGFILE}

--- a/bin/asl-tts
+++ b/bin/asl-tts
@@ -73,7 +73,7 @@ sox -V ${FILE} -r 8000 -c 1 -t ul ${FILE}.ul 2> ${LOGFILE}
 
 if [ ${MODE} == "SPEAK" ]; then
 	asterisk -x "rpt localplay ${NODE} ${FILE}"
-	rm ${FILE}
+	rm ${FILE}.ul
 fi
 
 


### PR DESCRIPTION
This pull requests adds another command line switch (-c) to allow for cleaning up the voice files that get created.  

Cleaning up the files was not straight forward as we have to allow time for Asterisk to play the files.  The time needed to play the file is calculated using soxi (part of the sox package).  A command line switch was added because of the delay incase others are relying it returning right away.

The cleanup is only done if playing directly to the node.

--- Kirk (VE6KIK)